### PR TITLE
Removed fixed version json-c dependency

### DIFF
--- a/net-fs/hubicfuse/hubicfuse-9999.ebuild
+++ b/net-fs/hubicfuse/hubicfuse-9999.ebuild
@@ -20,6 +20,6 @@ dev-libs/libxml2
 dev-libs/openssl
 net-misc/curl
 sys-fs/fuse
-=dev-libs/json-c-0.10-r1
+dev-libs/json-c
 "
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
Removed the dependency on specific version json-c-0.10. It compiles with current json-c-0.11 and upstream does not mention any limitation in that regard.
